### PR TITLE
WIP: rustlang gen_schema v2

### DIFF
--- a/rustlang/src/airtable.rs
+++ b/rustlang/src/airtable.rs
@@ -11,7 +11,7 @@ async fn fetch(client: reqwest::Client, url: Url, auth: &str) -> JSONResult {
 
 fn id_url(ctx: &FetchCtx, table: &str, id: &str) -> Result<Url> {
     let url = format!("{}/{}", ctx.config.table_url(table), id);
-    Url::parse(&url).map_err(Error::UrlParser)
+    (Url::parse(&url).map_err(Error::UrlParser)
 }
 
 fn query_url(ctx: &FetchCtx, table: &str, field: &str, value: &str) -> Result<Url> {

--- a/rustlang/src/airtable.rs
+++ b/rustlang/src/airtable.rs
@@ -11,7 +11,7 @@ async fn fetch(client: reqwest::Client, url: Url, auth: &str) -> JSONResult {
 
 fn id_url(ctx: &FetchCtx, table: &str, id: &str) -> Result<Url> {
     let url = format!("{}/{}", ctx.config.table_url(table), id);
-    (Url::parse(&url).map_err(Error::UrlParser)
+    Url::parse(&url).map_err(Error::UrlParser)
 }
 
 fn query_url(ctx: &FetchCtx, table: &str, field: &str, value: &str) -> Result<Url> {

--- a/rustlang/src/config.rs
+++ b/rustlang/src/config.rs
@@ -1,3 +1,5 @@
+use crate::error::Error;
+
 #[derive(Debug)]
 pub(crate) struct Config {
     pub key: String,
@@ -5,11 +7,14 @@ pub(crate) struct Config {
 }
 
 impl Config {
+    const KEYS: [&'static str; 2] = ["AIRTABLE_KEY", "AIRTABLE_APP"];
+
     pub(crate) fn from_env() -> Result<Self, crate::error::Error> {
-        use std::env;
-        match (env::var("AIRTABLE_KEY"), env::var("AIRTABLE_APP")) {
-            (Ok(key), Ok(base)) => Ok(Self { key, base }),
-            _ => Err(crate::error::Error::MissingEnvConfig),
+        match Self::KEYS {
+            [key, base] => match (std::env::var(key), std::env::var(base)) {
+                (Ok(key), Ok(base)) => Ok(Self { key, base }),
+                _ => Err(Error::MissingEnvConfig(Self::KEYS)),
+            },
         }
     }
 

--- a/rustlang/src/error.rs
+++ b/rustlang/src/error.rs
@@ -1,10 +1,11 @@
 use std::fmt::{Display, Formatter};
 
-#[derive(Debug)]
 pub enum Error {
+    Create(&'static str, Box<Error>),
     MissingEnvConfig([&'static str; 2]),
     Map(&'static str),
     Req(reqwest::Error),
+    Response { status: String, url: String },
     SerdeTransform(serde_json::error::Error),
     UrlParser(url::ParseError),
 }
@@ -13,13 +14,41 @@ impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> Result<(), std::fmt::Error> {
         use Error::*;
         match self {
+            Create(ref name, ref cause) => {
+                write!(f, "Could not create {}, caused by={}", name, cause)
+            }
             MissingEnvConfig(vars) => write!(f, "Expected environment vars: {:?}", vars),
             Map(ref e) => write!(f, "Mapping error: {}", e),
             Req(ref e) => write!(f, "Reqwest error: {}", e),
+            Response {
+                ref status,
+                ref url,
+            } => write!(f, "url={}, failed with status={}", url, status),
             SerdeTransform(ref e) => write!(f, "Deserialization error: {}", e),
             UrlParser(ref e) => write!(f, "Url formatting error: {}", e),
         }
     }
+}
+
+impl std::fmt::Debug for Error {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), std::fmt::Error> {
+        use Error::*;
+        match self {
+            Create(ref name, ref cause) => {
+                write!(f, "Could not create {}, caused by={}", name, cause)
+            }
+            MissingEnvConfig(vars) => write!(f, "Expected environment vars: {:?}", vars),
+            Map(ref e) => write!(f, "Mapping error: {}", e),
+            Req(ref e) => write!(f, "Reqwest error: {}", e),
+            Response {
+                ref status,
+                ref url,
+            } => write!(f, "url={}, failed with status={}", url, status),
+            SerdeTransform(ref e) => write!(f, "Deserialization error: {}", e),
+            UrlParser(ref e) => write!(f, "Url formatting error: {}", e),
+        }
+    }
+
 }
 
 impl warp::reject::Reject for Error {}

--- a/rustlang/src/error.rs
+++ b/rustlang/src/error.rs
@@ -1,25 +1,27 @@
+use std::fmt::{Display, Formatter};
+
 #[derive(Debug)]
 pub enum Error {
-    MissingEnvConfig,
+    MissingEnvConfig([&'static str; 2]),
     Map(&'static str),
     Req(reqwest::Error),
     SerdeTransform(serde_json::error::Error),
     UrlParser(url::ParseError),
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), std::fmt::Error> {
+        use Error::*;
         match self {
-            Error::MissingEnvConfig => write!(
-                f,
-                "Expected env variables AIRTABLE_KEY, and AIRTABLE_APP to be set"
-            ),
-            Error::Map(ref e) => write!(f, "Mapping error: {}", e),
-            Error::Req(ref e) => write!(f, "Reqwest error: {}", e),
-            Error::SerdeTransform(ref e) => write!(f, "Deserialization error: {}", e),
-            Error::UrlParser(ref e) => write!(f, "Url formatting error: {}", e),
+            MissingEnvConfig(vars) => write!(f, "Expected environment vars: {:?}", vars),
+            Map(ref e) => write!(f, "Mapping error: {}", e),
+            Req(ref e) => write!(f, "Reqwest error: {}", e),
+            SerdeTransform(ref e) => write!(f, "Deserialization error: {}", e),
+            UrlParser(ref e) => write!(f, "Url formatting error: {}", e),
         }
     }
 }
+
+impl warp::reject::Reject for Error {}
 
 impl std::error::Error for Error {}

--- a/rustlang/src/gen_schema.rs
+++ b/rustlang/src/gen_schema.rs
@@ -160,7 +160,12 @@ macro_rules! __gen_inner {
 
             pub async fn create_one(ctx: &mut FetchCtx, one: One<Fields>) -> Result<Self, Error> {
                 Ok(Self {
-                    $($name: compose!(ctx, one.fields.$name, [ $($($exec),*)? ])?),*
+                    $(
+                        $name: match compose!(ctx, one.fields.$name, [ $($($exec),*)? ]) {
+                            Ok(val) => val,
+                            Err(e) => return Err(Error::Create($table, Box::new(e))),
+                        }
+                     ),*
                 })
             }
 

--- a/rustlang/src/gen_schema.rs
+++ b/rustlang/src/gen_schema.rs
@@ -83,7 +83,7 @@ macro_rules! gen_airtable_schema {
                     let mut c = ctx.lock().await;
                     match f(&mut c, arg).await {
                         Ok(val) => Ok(warp::reply::json(&val)),
-                        Err(_) => Err(warp::reject::not_found())
+                        Err(e) => Err(warp::reject::custom(e))
                     }
                 }
             })*

--- a/rustlang/src/gen_schema.rs
+++ b/rustlang/src/gen_schema.rs
@@ -49,6 +49,14 @@ macro_rules! __gen_inner {
             // insert any module that's been done there, inlined
             $($($module)*)?
 
+            pub mod param {
+                #![allow(unused)]
+                use super::*;
+                pure_fn!(as_id_query(id: String) -> Param<Mapped> {
+                    Ok(Param::new_query("ID".to_string(), id))
+                });
+            }
+
             // generate an endpoints module
             pub mod endpoints {
                 #![allow(unused)]

--- a/rustlang/src/gen_schema.rs
+++ b/rustlang/src/gen_schema.rs
@@ -182,7 +182,7 @@ macro_rules! __gen_inner {
 }
 
 #[macro_export]
-macro_rules! gen_airtable_schema2 {
+macro_rules! gen_airtable_schema {
     ($($tt:tt)*) => {
         __gen_inner!{@main $($tt)*}
     }

--- a/rustlang/src/gen_schema.rs
+++ b/rustlang/src/gen_schema.rs
@@ -19,13 +19,15 @@ macro_rules! __gen_inner {
             use crate::network::response::One;
             use crate::transform::*;
             use serde::{Serialize, Deserialize};
+
+            // TODO: comment/splanations
             $(__gen_inner!{@table $name, stringify!($name), ($table) -> $out { $($inner)* }})*
 
             /// Generated `warp::Filter` for all endpoints created by the schema.
             pub fn route(ctx: crate::ctx::Ctx) -> impl warp::Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
                 use warp::Filter;
                 let ctx_cache = crate::ctx::ctx_cache::route(ctx.clone());
-                crate::build_route!(ctx, ctx_cache, [ ])
+                crate::build_route!(ctx, ctx_cache, [ $( $name::endpoints::route ),* ])
             }
         }
     };
@@ -85,11 +87,18 @@ macro_rules! __gen_inner {
                     .and_then(run)
             }
 
-            pub async fn run(arg: $from, ctx: Ctx) -> Result<impl Reply, Rejection> {
-                async fn handler(ctx: &mut FetchCtx, arg: $from) -> Result<$to, Error> {
-                    compose!(ctx, arg, [ $($($exec),*)? ])
-                }
+            async fn handler(ctx: &mut FetchCtx, arg: $from) -> Result<$to, Error> {
+                println!(
+                    "Executing generated handler module={} query_handler={} exec=[{}] arg={}",
+                    $mod_str_name,
+                    stringify!($name),
+                    stringify!( $($($exec),*)? ),
+                    arg
+                );
+                compose!(ctx, arg, [ $($($exec),*)? ])
+            }
 
+            pub async fn run(arg: $from, ctx: Ctx) -> Result<impl Reply, Rejection> {
                 let mut c = ctx.lock().await;
                 match handler(&mut c, arg).await {
                     Ok(val) => Ok(warp::reply::json(&val)),
@@ -100,8 +109,12 @@ macro_rules! __gen_inner {
         })*
 
         pub fn route(ctx: Ctx) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
-            let d = warp::get().map(|| { $mod_str_name });
-            crate::build_route!(ctx, d, [ $($name::route),* ])
+
+            let default_route = warp::path($mod_str_name)
+                .and(warp::get())
+                .map(|| format!("fine.... {}", $mod_str_name));
+
+            crate::build_route!(ctx, [ $($name::route),* ], default_route)
         }
     };
     //
@@ -180,14 +193,17 @@ macro_rules! build_route {
     ($ctx:expr, [ ]) => {
         unimplemented!("Missing any defined endpoints")
     };
-    ($ctx:expr, [ $name:expr ]) => {
+    ($ctx:expr, [ $name:expr ], $($default:expr)?) => {
         $name($ctx.clone())
     };
-    ($ctx:expr, [ $name:expr, $($ns:expr),+ ]) => {
+    ($ctx:expr, [ $name:expr, $($ns:expr),+ ], $($default:expr)?) => {
         build_route!($ctx, $name($ctx.clone()), [ $($ns),+ ])
     };
-    ($ctx:expr, $r:expr, [ $(,)* ]) => {
+    ($ctx:expr, $r:expr, [ ]) => {
         $r
+    };
+    ($ctx:expr, [ ], $default:expr) => {
+        $default
     };
     ($ctx:expr, $r:expr, [ $name:expr ]) => {
         $r.or($name($ctx.clone()))
@@ -198,192 +214,4 @@ macro_rules! build_route {
     ($ctx:expr, $r:expr, [ $name:expr, $($ns:expr),+ ]) => {
         build_route!($ctx, $r.or($name($ctx.clone())), [ $($ns),+ ])
     };
-}
-
-///
-/// Generates type definitions for a specific airtable record type,
-/// in a module... the structs are built to be deserializable.
-///
-#[macro_export]
-macro_rules! gen_airtable_schema {
-    (
-        @endpoints_route $ns:ident { $($_:tt),* }
-    ) => {
-        $ns::endpoints::route
-    };
-    (
-        @endpoints $ns_name:expr; $(
-            $name:ident($arg_type:ty) -> $out_type:ty {
-                $($t:expr),*
-            }
-        )*
-    ) => {
-        //
-        // Generated endpoints using the `endpoints` part
-        // of the grammar/macro.
-        //
-        // Each endpoint that's defined goes into its own module, with the actual endpoint
-        // functionality in `::run`, and the defined `warp` filter as `::route`.
-        //
-        // The main module will have a `route` that composes all of the ones internal.
-        // :cool:
-        pub mod endpoints {
-
-            use super::*;
-            use crate::ctx::{Ctx};
-            use warp::{Filter, Reply, Rejection};
-
-            pub fn route(ctx: Ctx) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
-                let default = warp::get().map(|| {
-                    ":shrug:"
-                });
-                crate::build_route!(ctx, default, [ $($name::route),* ])
-            }
-
-            $(pub mod $name {
-
-                use super::*;
-                use crate::ctx::with_ctx;
-
-                pub fn route(ctx: Ctx) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
-                    use warp::Filter;
-                    warp::path($ns_name)
-                        .and(warp::path::param::<$arg_type>())
-                        .and(warp::get())
-                        .and(with_ctx(ctx))
-                        .and_then(run)
-                }
-
-                pub async fn run(arg: $arg_type, ctx: Ctx) -> Result<impl Reply, Rejection> {
-                    async fn f(ctx: &mut FetchCtx, arg: $arg_type) -> Result<$out_type, Error> {
-                        compose!(ctx, arg, [ $($t),* ])
-                    }
-                    let mut c = ctx.lock().await;
-                    match f(&mut c, arg).await {
-                        Ok(val) => Ok(warp::reply::json(&val)),
-                        Err(e) => Err(warp::reject::custom(e))
-                    }
-                }
-            })*
-
-        }
-    };
-
-    (
-        @gen $(
-            $ns:ident, $ns_name:expr, $name:expr, $mapped_name:ident [ $(
-                $json_name:expr, $field_name:ident, $field_type:ty, -> [ $($t:expr,)* ]: $t_field:ty
-            )*], { mod $($mod_tokens:tt)* } { endpoints $($endpoints_tokens:tt)* }
-        )*
-    ) => {
-
-        use crate::airtable::FetchCtx;
-        use crate::gen_schema::Table;
-        use crate::network::response::One;
-        use crate::compose;
-        use serde::{Serialize, Deserialize};
-
-        $(
-            pub mod $ns {
-
-                use super::*;
-
-                #[allow(unused)]
-                #[derive(Debug, Deserialize)]
-                pub struct Fields {
-                    $( #[serde(rename = $json_name)] pub $field_name: $field_type,)*
-                }
-
-                #[allow(unused)]
-                #[derive(Debug, Serialize)]
-                pub struct Mapped {
-                    $( pub $field_name: $t_field, )*
-                }
-
-                $($mod_tokens)*
-
-                gen_airtable_schema!(@endpoints $ns_name; $($endpoints_tokens)*);
-            }
-
-            pub type $mapped_name = $ns::Mapped;
-
-            impl Table for $mapped_name {
-                const NAME: &'static str = $name;
-                type Fields = $ns::Fields;
-            }
-
-            #[allow(unused)]
-            impl $mapped_name {
-
-                pub async fn create_one(ctx: &mut FetchCtx, one: One<$ns::Fields>) -> Result<Self,  Error> {
-                    Ok(Self {
-                        $($field_name: compose!(ctx, one.fields.$field_name, [ $($t),* ])?),*
-                    })
-                }
-
-                pub async fn create_many(ctx: &mut FetchCtx, many: Vec<One<$ns::Fields>>) -> Result<Vec<Self>, Error> {
-                    // TODO: this should not block/await on each loop,
-                    // but let them all run in parallel until they're done,
-                    // then we can accumulate them into the output vector.
-                    let mut result = Vec::with_capacity(many.len());
-                    for one in many {
-                        result.push(Self::create_one(ctx, one).await?);
-                    }
-                    Ok(result)
-                }
-
-                pub async fn fetch_and_create_first(ctx: &mut FetchCtx, ids: Vec<String>) -> Result<Self, Error> {
-                    let params: Param<Self> = Param::new_id(ids);
-                    compose!(ctx, params, [ one, Self::create_one ])
-                }
-
-                pub async fn fetch_and_create_many(ctx: &mut FetchCtx, ids: Vec<String>) -> Result<Vec<Self>, Error> {
-                    let params: Param<Self> = Param::new_id(ids);
-                    compose!(ctx, params, [ many, Self::create_many ])
-                }
-
-            }
-
-
-        )*  // end for each
-
-        /// Generated `warp::Filter` for all endpoints created by the schema.
-        pub fn route(ctx: crate::ctx::Ctx) -> impl warp::Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
-            use warp::Filter;
-            let ctx_cache = crate::ctx::ctx_cache::route(ctx.clone());
-            crate::build_route!(ctx, ctx_cache, [
-                $(
-                    gen_airtable_schema!(@endpoints_route $ns { $($endpoints_tokens),* })
-                ),*
-            ])
-        }
-
-    };
-
-    // This is the main user entrypoint into this macro, it forwards to the `@gen`,
-    // stringifying the `ns` names so that they can be used as strings.
-    (
-        $(
-            $ns:ident ($name: expr)
-                as $mapped_name:ident {
-                    $(
-                        $k:expr => fn $fn:ident ($ft:ty) -> $t_ft:ty { $($tfs:expr),+ },
-                    )*
-                },
-                mod { $($mod_tokens:tt)* },
-                endpoints { $($endpoints_tokens:tt)* };
-        )*
-    ) => {
-        gen_airtable_schema! {
-            @gen $(
-                $ns, stringify!($ns), $name, $mapped_name [
-                    $(
-                        $k, $fn, $ft, -> [ $($tfs,)* ]: $t_ft
-                     )*
-                ],
-                { mod $($mod_tokens)* }
-                { endpoints $($endpoints_tokens)* }
-            )*
-        }
-    }
 }

--- a/rustlang/src/main.rs
+++ b/rustlang/src/main.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // that `route` methods should probably return a tuple
     // of the `warp::Filter` with some `Debug` struct that we
     // can output here.
-    let router = schema::route(ctx);
+    let router = schema::gen::route(ctx);
 
     println!("Will be serving the app on {}", address);
     warp::serve(router).run(address).await;

--- a/rustlang/src/network/cache.rs
+++ b/rustlang/src/network/cache.rs
@@ -1,4 +1,5 @@
-use reqwest::{Error, Url};
+use crate::error::Error;
+use reqwest::Url;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::future::Future;

--- a/rustlang/src/schema.rs
+++ b/rustlang/src/schema.rs
@@ -8,8 +8,8 @@ gen_airtable_schema2! {
 
     invoice_rate_unit("Invoice Units") -> InvoiceRateUnit {
         fields {
-            name(String) -> String {
-                name = "Name";
+            name {
+                source = "Name";
             }
         }
         module {
@@ -22,21 +22,21 @@ gen_airtable_schema2! {
 
     invoice_item_rate("Invoice Rates") -> InvoiceRate {
         fields {
-            name(String) -> String {
-                name = "Name";
+            name {
+                source = "Name";
             }
-            notes(Option<String>) -> Option<String> {
-                name = "Notes";
+            notes -> Option<String> {
+                source = "Notes";
             }
-            quantity(u32) -> u32 {
-                name = "Quantity";
+            quantity {
+                source = "Quantity";
             }
             amount(u32) -> String {
-                name = "Amount";
+                source = "Amount";
                 exec = money;
             }
             unit(IDs) -> String {
-                name = "Unit";
+                source = "Unit";
                 exec = InvoiceRateUnit::fetch_and_create_first, invoice_rate_unit::get_name;
             }
         }
@@ -44,17 +44,17 @@ gen_airtable_schema2! {
 
     invoice_item("Invoice Item") -> InvoiceItem {
         fields {
-            date(String) -> String {
-                name = "Date";
+            date {
+                source = "Date";
             }
-            description(String) -> String {
-                name = "Description";
+            description {
+                source = "Description";
             }
-            quantity(u32) -> u32 {
-                name = "Quantity";
+            quantity {
+                source = "Quantity";
             }
             rate(IDs) -> InvoiceRate {
-                name = "Invoice Rate";
+                source = "Invoice Rate";
                 exec = InvoiceRate::fetch_and_create_first;
             }
         }
@@ -62,31 +62,31 @@ gen_airtable_schema2! {
 
     invoice_client("Clients") -> InvoiceClient {
         fields {
-            company(String) -> String {
-                name = "Company";
+            company {
+                source = "Company";
             }
-            contact_email(String) -> String {
-                name = "ContactEmail";
+            contact_email {
+                source = "ContactEmail";
             }
-            contact_name(String) -> String {
-                name = "ContactName";
+            contact_name {
+                source = "ContactName";
             }
-            website_url(String) -> String {
-                name = "Website";
+            website_url {
+                source = "Website";
             }
         }
     }
 
     invoice_from("Me") -> InvoiceFrom {
         fields {
-            name(String) -> String {
-                name = "Name";
+            name {
+                source = "Name";
             }
-            email(String) -> String {
-                name = "Email";
+            email {
+                source = "Email";
             }
             address(String) -> Vec<String> {
-                name = "Address";
+                source = "Address";
                 exec = split_lines;
             }
         }
@@ -94,44 +94,55 @@ gen_airtable_schema2! {
 
     invoice("Invoice") -> Invoice {
         fields {
-            id(u32) -> u32 {
-                name = "ID";
+            id {
+                source = "ID";
             }
-            number(String) -> String {
-                name = "Invoice Number";
+            number {
+                source = "Invoice Number";
             }
-            notes(String) -> String {
-                name = "Notes";
+            notes {
+                source = "Notes";
             }
-            date(String) -> String {
-                name = "Date";
+            date {
+                source = "Date";
             }
-            due_date(String) -> String {
-                name = "Due Date";
+            due_date {
+                source = "Due Date";
             }
             was_sent(MaybeBool) -> bool {
-                name = "Sent?";
+                source = "Sent?";
                 exec = force_bool;
             }
             was_paid(MaybeBool) -> bool {
-                name = "Paid?";
+                source = "Paid?";
                 exec = force_bool;
             }
             total(u32) -> String {
-                name = "Total Amount";
+                source = "Total Amount";
                 exec = money;
             }
             from(IDs) -> InvoiceFrom {
-                name = "From";
+                source = "From";
                 exec = InvoiceFrom::fetch_and_create_first;
             }
             client(IDs) -> InvoiceClient {
-                name = "Client";
+                source = "Client";
                 exec = InvoiceClient::fetch_and_create_first;
             }
             items(IDs) -> Vec<InvoiceItem> {
-                name = "Invoice Item";
+                source = "Invoice Item";
                 exec = InvoiceItem::fetch_and_create_many;
+            }
+        }
+        module {
+            pure_fn!(id_query(id: String) -> Param<Mapped> {
+                Ok(Param::new_query("ID".to_string(), id))
+            });
+        }
+        endpoints {
+            query_by_invoice_id(String) -> Invoice {
+                path = String;
+                exec = id_query, one, Invoice::create_one;
             }
         }
     }

--- a/rustlang/src/schema.rs
+++ b/rustlang/src/schema.rs
@@ -15,9 +15,6 @@ gen_airtable_schema2! {
         module {
             pure_fn!(get_name(unit: Mapped) -> String { Ok(unit.name) });
         }
-        endpoints {
-
-        }
     }
 
     invoice_item_rate("Invoice Rates") -> InvoiceRate {
@@ -141,7 +138,7 @@ gen_airtable_schema2! {
         }
         endpoints {
             query_by_invoice_id(String) -> Invoice {
-                path = String;
+                url_path { String }
                 exec = id_query, one, Invoice::create_one;
             }
         }

--- a/rustlang/src/schema.rs
+++ b/rustlang/src/schema.rs
@@ -25,12 +25,8 @@ gen_airtable_schema2! {
             notes -> Option<String> {
                 source = "Notes";
             }
-            quantity {
-                source = "Quantity";
-            }
-            amount(u32) -> String {
-                source = "Amount";
-                exec = money;
+            rate -> u32 {
+                source = "Rate";
             }
             unit(IDs) -> String {
                 source = "Unit";
@@ -47,8 +43,12 @@ gen_airtable_schema2! {
             description {
                 source = "Description";
             }
-            quantity {
+            quantity -> u32 {
                 source = "Quantity";
+            }
+            amount(u32) -> String {
+                source = "Amount";
+                exec = money;
             }
             rate(IDs) -> InvoiceRate {
                 source = "Invoice Rate";
@@ -91,13 +91,13 @@ gen_airtable_schema2! {
 
     invoice("Invoice") -> Invoice {
         fields {
-            id {
+            id -> u32 {
                 source = "ID";
             }
             number {
                 source = "Invoice Number";
             }
-            notes {
+            notes -> Option<String> {
                 source = "Notes";
             }
             date {
@@ -144,108 +144,4 @@ gen_airtable_schema2! {
         }
     }
 
-    /*
-    invoice_rate_unit("Invoice Units")
-        as InvoiceUnit {
-            "Name" => fn name(String) -> String { id },
-        },
-        mod {
-            pure_fn!(get_name(unit: Mapped) -> String { Ok(unit.name) });
-        }, endpoints { };
-
-    invoice_item_rate("Invoice Rates")
-        as InvoiceRate {
-            "Name" => fn name(String) -> String { id },
-            "Notes" => fn notes(Option<String>) -> Option<String> { id },
-            "Rate" => fn rate(u32) -> u32 { copy },
-            "Unit" => fn unit(IDs) -> String {
-                InvoiceUnit::fetch_and_create_first,
-                invoice_rate_unit::get_name
-            },
-        }, mod { }, endpoints { };
-
-    invoice_item("Invoice Item")
-        as InvoiceItem {
-            "Date" => fn date(String) -> String { id },
-            "Description" => fn description(String) -> String { id },
-            "Quantity" => fn quantity(u32) -> u32 { copy },
-            "Amount" => fn amount(u32) -> String { money },
-            "Invoice Rate" => fn rate(IDs) -> InvoiceRate {
-                InvoiceRate::fetch_and_create_first
-            },
-        }, mod { }, endpoints { };
-
-    invoice_client("Clients")
-        as InvoiceClient {
-            "Company" => fn company(String) -> String { id },
-            "ContactEmail" => fn contact_email(String) -> String { id },
-            "ContactName" => fn contact_name(String) -> String { id },
-            "Website" => fn website_url(String) -> String { id },
-        }, mod { }, endpoints { };
-
-    invoice_from("Me")
-        as InvoiceFrom {
-            "Name" => fn name(String) -> String { id },
-            "Email" => fn email(String) -> String { id },
-            "Address" => fn address(String) -> Vec<String> { split_lines },
-        },
-        mod { },
-        endpoints {
-            query(String) -> InvoiceFrom {
-                into_vec,
-                InvoiceFrom::fetch_and_create_first
-            }
-        };
-
-    invoice("Invoice") -> Invoice {
-        fields {
-            id(u32) -> u32 {
-                name = "ID";
-            }
-            number(String) -> String {
-                name = "Invoice Number";
-            }
-        }
-        endpoints {
-
-        }
-    }
-
-    invoice("Invoice")
-        as Invoice {
-            "ID" => fn id(u32) -> u32 { copy },
-            "Invoice Number" => fn number(String) -> String { id },
-            "Notes" => fn notes(Option<String>) -> Option<String> { id },
-            "Date" => fn date(String) -> String { id },
-            "Due Date" => fn due_date(String) -> String { id },
-            "Sent?" => fn was_sent(MaybeBool) -> bool { force_bool },
-            "Paid?" => fn was_paid(MaybeBool) -> bool { force_bool },
-            "Total Amount" => fn total(u32) -> String { money },
-            "From" => fn from(IDs) -> InvoiceFrom {
-                InvoiceFrom::fetch_and_create_first
-            },
-            "Client" => fn client(IDs) -> InvoiceClient {
-                InvoiceClient::fetch_and_create_first
-            },
-            "Invoice Item" => fn items(IDs) -> Vec<InvoiceItem> {
-                InvoiceItem::fetch_and_create_many
-            },
-        },
-        mod {
-            pure_fn!(id_query(id: String) -> Param<Invoice> {
-                Ok(Param::new_query("ID".to_string(), id))
-            });
-        },
-        endpoints {
-            query_by_invoice_id(String) -> Invoice {
-                path = String;
-                exec = id_query, one, Invoice::create_one;
-            }
-            find_by_record_id(String) -> Invoice {
-                path = "record" / String;
-                exec = into_vec, Invoice::fetch_and_create_first;
-            }
-        };
-
-            */
 }

--- a/rustlang/src/schema.rs
+++ b/rustlang/src/schema.rs
@@ -4,20 +4,146 @@ use crate::error::Error;
 use crate::network::request::*;
 use crate::transform::*;
 
-gen_airtable_schema! {
+gen_airtable_schema2! {
 
+    invoice_rate_unit("Invoice Units") -> InvoiceRateUnit {
+        fields {
+            name(String) -> String {
+                name = "Name";
+            }
+        }
+        module {
+            pure_fn!(get_name(unit: Mapped) -> String { Ok(unit.name) });
+        }
+        endpoints {
+
+        }
+    }
+
+    invoice_item_rate("Invoice Rates") -> InvoiceRate {
+        fields {
+            name(String) -> String {
+                name = "Name";
+            }
+            notes(Option<String>) -> Option<String> {
+                name = "Notes";
+            }
+            quantity(u32) -> u32 {
+                name = "Quantity";
+            }
+            amount(u32) -> String {
+                name = "Amount";
+                exec = money;
+            }
+            unit(IDs) -> String {
+                name = "Unit";
+                exec = InvoiceRateUnit::fetch_and_create_first, invoice_rate_unit::get_name;
+            }
+        }
+    }
+
+    invoice_item("Invoice Item") -> InvoiceItem {
+        fields {
+            date(String) -> String {
+                name = "Date";
+            }
+            description(String) -> String {
+                name = "Description";
+            }
+            quantity(u32) -> u32 {
+                name = "Quantity";
+            }
+            rate(IDs) -> InvoiceRate {
+                name = "Invoice Rate";
+                exec = InvoiceRate::fetch_and_create_first;
+            }
+        }
+    }
+
+    invoice_client("Clients") -> InvoiceClient {
+        fields {
+            company(String) -> String {
+                name = "Company";
+            }
+            contact_email(String) -> String {
+                name = "ContactEmail";
+            }
+            contact_name(String) -> String {
+                name = "ContactName";
+            }
+            website_url(String) -> String {
+                name = "Website";
+            }
+        }
+    }
+
+    invoice_from("Me") -> InvoiceFrom {
+        fields {
+            name(String) -> String {
+                name = "Name";
+            }
+            email(String) -> String {
+                name = "Email";
+            }
+            address(String) -> Vec<String> {
+                name = "Address";
+                exec = split_lines;
+            }
+        }
+    }
+
+    invoice("Invoice") -> Invoice {
+        fields {
+            id(u32) -> u32 {
+                name = "ID";
+            }
+            number(String) -> String {
+                name = "Invoice Number";
+            }
+            notes(String) -> String {
+                name = "Notes";
+            }
+            date(String) -> String {
+                name = "Date";
+            }
+            due_date(String) -> String {
+                name = "Due Date";
+            }
+            was_sent(MaybeBool) -> bool {
+                name = "Sent?";
+                exec = force_bool;
+            }
+            was_paid(MaybeBool) -> bool {
+                name = "Paid?";
+                exec = force_bool;
+            }
+            total(u32) -> String {
+                name = "Total Amount";
+                exec = money;
+            }
+            from(IDs) -> InvoiceFrom {
+                name = "From";
+                exec = InvoiceFrom::fetch_and_create_first;
+            }
+            client(IDs) -> InvoiceClient {
+                name = "Client";
+                exec = InvoiceClient::fetch_and_create_first;
+            }
+            items(IDs) -> Vec<InvoiceItem> {
+                name = "Invoice Item";
+                exec = InvoiceItem::fetch_and_create_many;
+            }
+        }
+    }
+
+    /*
     invoice_rate_unit("Invoice Units")
         as InvoiceUnit {
             "Name" => fn name(String) -> String { id },
         },
         mod {
             pure_fn!(get_name(unit: Mapped) -> String { Ok(unit.name) });
-        }, endpoints {
-            query(String) -> InvoiceItem {
-                into_vec,
-                InvoiceItem::fetch_and_create_first
-            }
-        };
+        }, endpoints { };
 
     invoice_item_rate("Invoice Rates")
         as InvoiceRate {
@@ -28,13 +154,7 @@ gen_airtable_schema! {
                 InvoiceUnit::fetch_and_create_first,
                 invoice_rate_unit::get_name
             },
-        }, mod {
-        }, endpoints {
-            query(String) -> InvoiceItem {
-                into_vec,
-                InvoiceItem::fetch_and_create_first
-            }
-        };
+        }, mod { }, endpoints { };
 
     invoice_item("Invoice Item")
         as InvoiceItem {
@@ -45,13 +165,7 @@ gen_airtable_schema! {
             "Invoice Rate" => fn rate(IDs) -> InvoiceRate {
                 InvoiceRate::fetch_and_create_first
             },
-        }, mod {
-        }, endpoints {
-            query(String) -> InvoiceItem {
-                into_vec,
-                InvoiceItem::fetch_and_create_first
-            }
-        };
+        }, mod { }, endpoints { };
 
     invoice_client("Clients")
         as InvoiceClient {
@@ -59,13 +173,7 @@ gen_airtable_schema! {
             "ContactEmail" => fn contact_email(String) -> String { id },
             "ContactName" => fn contact_name(String) -> String { id },
             "Website" => fn website_url(String) -> String { id },
-        }, mod {
-        }, endpoints {
-            query(String) -> InvoiceClient {
-                into_vec,
-                InvoiceClient::fetch_and_create_first
-            }
-        };
+        }, mod { }, endpoints { };
 
     invoice_from("Me")
         as InvoiceFrom {
@@ -80,6 +188,20 @@ gen_airtable_schema! {
                 InvoiceFrom::fetch_and_create_first
             }
         };
+
+    invoice("Invoice") -> Invoice {
+        fields {
+            id(u32) -> u32 {
+                name = "ID";
+            }
+            number(String) -> String {
+                name = "Invoice Number";
+            }
+        }
+        endpoints {
+
+        }
+    }
 
     invoice("Invoice")
         as Invoice {
@@ -107,11 +229,15 @@ gen_airtable_schema! {
             });
         },
         endpoints {
-            query(String) -> Invoice {
-                id_query,
-                one,
-                Invoice::create_one
+            query_by_invoice_id(String) -> Invoice {
+                path = String;
+                exec = id_query, one, Invoice::create_one;
+            }
+            find_by_record_id(String) -> Invoice {
+                path = "record" / String;
+                exec = into_vec, Invoice::fetch_and_create_first;
             }
         };
 
+            */
 }

--- a/rustlang/src/schema.rs
+++ b/rustlang/src/schema.rs
@@ -1,3 +1,4 @@
+#![allow(unused)]
 use super::*;
 use crate::error::Error;
 use crate::network::request::*;
@@ -11,6 +12,11 @@ gen_airtable_schema! {
         },
         mod {
             pure_fn!(get_name(unit: Mapped) -> String { Ok(unit.name) });
+        }, endpoints {
+            query(String) -> InvoiceItem {
+                into_vec,
+                InvoiceItem::fetch_and_create_first
+            }
         };
 
     invoice_item_rate("Invoice Rates")
@@ -22,6 +28,12 @@ gen_airtable_schema! {
                 InvoiceUnit::fetch_and_create_first,
                 invoice_rate_unit::get_name
             },
+        }, mod {
+        }, endpoints {
+            query(String) -> InvoiceItem {
+                into_vec,
+                InvoiceItem::fetch_and_create_first
+            }
         };
 
     invoice_item("Invoice Item")
@@ -33,6 +45,12 @@ gen_airtable_schema! {
             "Invoice Rate" => fn rate(IDs) -> InvoiceRate {
                 InvoiceRate::fetch_and_create_first
             },
+        }, mod {
+        }, endpoints {
+            query(String) -> InvoiceItem {
+                into_vec,
+                InvoiceItem::fetch_and_create_first
+            }
         };
 
     invoice_client("Clients")
@@ -41,6 +59,12 @@ gen_airtable_schema! {
             "ContactEmail" => fn contact_email(String) -> String { id },
             "ContactName" => fn contact_name(String) -> String { id },
             "Website" => fn website_url(String) -> String { id },
+        }, mod {
+        }, endpoints {
+            query(String) -> InvoiceClient {
+                into_vec,
+                InvoiceClient::fetch_and_create_first
+            }
         };
 
     invoice_from("Me")
@@ -48,6 +72,13 @@ gen_airtable_schema! {
             "Name" => fn name(String) -> String { id },
             "Email" => fn email(String) -> String { id },
             "Address" => fn address(String) -> Vec<String> { split_lines },
+        },
+        mod { },
+        endpoints {
+            query(String) -> InvoiceFrom {
+                into_vec,
+                InvoiceFrom::fetch_and_create_first
+            }
         };
 
     invoice("Invoice")

--- a/rustlang/src/schema.rs
+++ b/rustlang/src/schema.rs
@@ -4,7 +4,7 @@ use crate::error::Error;
 use crate::network::request::*;
 use crate::transform::*;
 
-gen_airtable_schema2! {
+gen_airtable_schema! {
 
     invoice_rate_unit("Invoice Units") -> InvoiceRateUnit {
         fields {

--- a/rustlang/src/schema.rs
+++ b/rustlang/src/schema.rs
@@ -131,15 +131,14 @@ gen_airtable_schema! {
                 exec = InvoiceItem::fetch_and_create_many;
             }
         }
-        module {
-            pure_fn!(id_query(id: String) -> Param<Mapped> {
-                Ok(Param::new_query("ID".to_string(), id))
-            });
-        }
         endpoints {
             query_by_invoice_id(String) -> Invoice {
                 url_path { String }
-                exec = id_query, one, Invoice::create_one;
+                exec = param::as_id_query, one, Invoice::create_one;
+            }
+            find_by_record_id(String) -> Invoice {
+                url_path { String }
+                exec = into_vec, Invoice::fetch_and_create_first;
             }
         }
     }

--- a/rustlang/src/transform.rs
+++ b/rustlang/src/transform.rs
@@ -7,6 +7,8 @@
 //! 4. return a `Result<_, Error>` which is defined below.
 //!
 
+#![allow(unused)]
+
 use crate::airtable::FetchCtx;
 use crate::error::Error;
 
@@ -83,4 +85,8 @@ fn get_first<T>(mut vec: Vec<T>) -> Result<T, Error> {
 
 pure_fn!(first<T>(vec: Vec<T>) -> T {
     get_first(vec)
+});
+
+pure_fn!(into_vec<T>(value: T) -> Vec<T> {
+    Ok(vec![value])
 });


### PR DESCRIPTION
@bdelanghe 

I'm updating the grammar rules for how to define schemas to make them a little more regular, as well as more flexible to optional things.

This is mostly working, but the endpoint stuff isn't at 💯 yet.

## Example:

### Table/Fields before:

```
table_module_alias_name("Source Table Name") as TableType {
    "Field1" => fn field1(String) -> String { id },
    // ...
}
```

### Table/Fields after:

```
table_module_alias_name("Source Table Name") -> TableType {
    fields {
        field1(String) -> String {
            source = "Field1";
            exec = id;
        }
    }
}
```

This is a bit more verbose, but the way the grammar is defined it means that `exec` is optional, so we can also write this for the field:

```
field1(String) -> String {
    source = "Field1";
}
```

_Also,_ the input type is optional, and if it's left out will, it will default to the same thing as the output type. So we can write this shorter:

```
field1 -> String {
    source = "Field1";
}
```

_Also,_ the output type is optional as well, and missing both will default everything to `String`. So it can get even shorter.

```
field1 { source = "Field1"; }
```

Rewinding, we can get the whole **prior** state to be re-written as:

```
table_module_alias_name("Source Table Name") -> TableType {
    fields {
        field1 { source = "Field1"; }
    }
}
```

## Overall idea

I'm trying to simplify the rules so that they can be more flexible for multiple cases, so the general form of a rule/line-item/whatever is:

```
name(InputType) -> OutputType {
   <OPTIONS>
}
```

Where some parts of the name/fn signature can be removed if they have obvious defaults, like for fields, and `OPTIONS` can either be stuff like `key = value;` or blocks/groups of 'em.

So far, defined groups are only on tables,

- `fields`
- `module`
- `endpoints`

This will also make endpoint structure look similar to field/table structure, and we should then be able to 🤞 support `POST` in addition to `GET` requests, as well as more _complicated_ (complicated per the current schema) urls.
